### PR TITLE
Fix GoogleMapPlotter class

### DIFF
--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -16,7 +16,7 @@ def safe_iter(var):
 class GoogleMapPlotter(object):
 
     def __init__(self, center_lat, center_lng, zoom):
-        self.center = (float(centerLat), float(centerLng))
+        self.center = (float(center_lat), float(center_lng))
         self.zoom = int(zoom)
         self.grids = None
         self.paths = []


### PR DESCRIPTION
We have a problem with the GoogleMapPlotter class, and can't import it anymore. The fix is simply change the variable names
```python
#from
centerLat
centerLng
#to
center_lat
center_lng
```