### PR TITLE
Add Google API key to arguments

### DIFF
--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -15,9 +15,10 @@ def safe_iter(var):
 
 class GoogleMapPlotter(object):
 
-    def __init__(self, center_lat, center_lng, zoom):
+    def __init__(self, center_lat, center_lng, zoom, apikey=''):
         self.center = (float(center_lat), float(center_lng))
         self.zoom = int(zoom)
+        self.apikey = string(apikey)
         self.grids = None
         self.paths = []
         self.shapes = []
@@ -179,7 +180,10 @@ class GoogleMapPlotter(object):
         f.write(
             '<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>\n')
         f.write('<title>Google Maps - pygmaps </title>\n')
-        f.write('<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?libraries=visualization&sensor=true_or_false"></script>\n')
+        if self.apikey:
+            f.write('<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?libraries=visualization&sensor=true_or_false&key=%s"></script>\n' % self.apikey )
+        else:
+            f.write('<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?libraries=visualization&sensor=true_or_false"></script>\n' )
         f.write('<script type="text/javascript">\n')
         f.write('\tfunction initialize() {\n')
         self.write_map(f)

--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -18,7 +18,7 @@ class GoogleMapPlotter(object):
     def __init__(self, center_lat, center_lng, zoom, apikey=''):
         self.center = (float(center_lat), float(center_lng))
         self.zoom = int(zoom)
-        self.apikey = string(apikey)
+        self.apikey = str(apikey)
         self.grids = None
         self.paths = []
         self.shapes = []

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()


### PR DESCRIPTION
To use gmplot in Jupyter, end in:
`gmap.draw("mymap.html")`
`from IPython.display import IFrame`
`IFrame('mymap.html', width=990, height=500)`
This leads to rejection from the Google JS API, as Jupyter/Tornado does not provide an API key -- reported on the JS console.
This patch helps to pass such an API key when loading the JS engine.
