### PR TITLE
Fixed gmplot.py import error : "from .color_dicts" to " from color_dicts"

### DIFF
--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -3,7 +3,7 @@ import requests
 import json
 import os
 
-from .color_dicts import mpl_color_map, html_color_codes
+from color_dicts import mpl_color_map, html_color_codes
 
 
 def safe_iter(var):


### PR DESCRIPTION
### Steps to reproduce
```
$ git clone https://github.com/vgm64/gmplot.git
$ python ./gmplot/gmplot.py
```

### Expected behavior

Produce mymap.html (./gmplot/)

### Actual behavior

Traceback (most recent call last):
File "gmplot.py", line 6, in 
from .color_dicts import mpl_color_map, html_color_codes
ValueError: Attempted relative import in non-package

### Codes to fix
```python
from .color_dicts import mpl_color_map, html_color_codes # before
from color_dicts import mpl_color_map, html_color_codes # after
```

### System configuration
python==2.7.11
gmplot==1.2.0