### PR TITLE
Add parameter to set heat map max intensity

### DIFF
--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -120,10 +120,11 @@ class GoogleMapPlotter(object):
         path = zip(lats, lngs)
         self.paths.append((path, settings))
 
-    def heatmap(self, lats, lngs, threshold=10, radius=10, gradient=None, opacity=0.6, dissipating=True):
+    def heatmap(self, lats, lngs, threshold=10, radius=10, gradient=None, opacity=0.6, maxIntensity=None, dissipating=True):
         """
         :param lats: list of latitudes
         :param lngs: list of longitudes
+        :param maxIntensity:(int) max frequency to use when plotting. Default (None) uses max value on map domain.
         :param threshold:
         :param radius: The hardest param. Example (string):
         :return:
@@ -133,6 +134,7 @@ class GoogleMapPlotter(object):
         settings['radius'] = radius
         settings['gradient'] = gradient
         settings['opacity'] = opacity
+        settings['maxIntensity'] = maxIntensity
         settings['dissipating'] = dissipating
         settings = self._process_heatmap_kwargs(settings)
 
@@ -145,6 +147,7 @@ class GoogleMapPlotter(object):
         settings_string = ''
         settings_string += "heatmap.set('threshold', %d);\n" % settings_dict['threshold']
         settings_string += "heatmap.set('radius', %d);\n" % settings_dict['radius']
+        settings_string += "heatmap.set('maxIntensity', %d);\n" % settings_dict['maxIntensity']
         settings_string += "heatmap.set('opacity', %f);\n" % settings_dict['opacity']
 
         dissipation_string = 'true' if settings_dict['dissipating'] else 'false'


### PR DESCRIPTION
The default max intensity used in Google Heat Maps is to take the
maximum frequency on the map as the max value, and then scale the
rest of the map according to that value. If you aim to make multiple
heat maps and compare them to one another then you might want the
ability to set the max "heat" yourself, so that all maps are on
the same color scale. Also useful for removing the influence of any
possible outliers. See below for a more thorough description of the
maxIntensity parameter from Google's documentation. Adding this
functionality to gmplot.py requires only minor additions to existing
version.

Specific code changes:
- Added maxIntensity parameter to the heatmap method. This parameter
gets added to the settings dictionary. (lines 123, 127, 137)
- Added string formating to the settings_string within the
_process_heatmap_kwargs method. (line 150)

Google's description of the maxIntensity parameter:
The maximum intensity of the heatmap. By default, heatmap colors are
dynamically scaled according to the greatest concentration of points
at any particular pixel on the map. This property allows you to specify
a fixed maximum. Setting the maximum intensity can be helpful when your
dataset contains a few outliers with an unusually high intensity.