### PR TITLE
Adding GroundOverlay feature to gmplot

### DIFF
--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -26,6 +26,7 @@ class GoogleMapPlotter(object):
         self.shapes = []
         self.points = []
         self.heatmap_points = []
+        self.groundoverlays = []
         self.radpoints = []
         self.gridsetting = None
         self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png')
@@ -167,6 +168,25 @@ class GoogleMapPlotter(object):
 
         return settings_string
 
+    def groundoverlay(self, url, bounds_dict):
+        """
+
+        """
+
+        bounds_string = self._process_groundoverlay_image_bounds(bounds_dict)
+
+        self.groundoverlays.append((url, bounds_string))
+
+    def _process_groundoverlay_image_bounds(self, bounds_dict):
+
+        bounds_string = 'var imageBounds = {'
+        bounds_string += "north:  %.4f,\n" % bounds_dict['north']
+        bounds_string += "south:  %.4f,\n" % bounds_dict['south']
+        bounds_string += "east:  %.4f,\n" % bounds_dict['east']
+        bounds_string += "west:  %.4f};\n" % bounds_dict['west']
+
+        return bounds_string
+
     def polygon(self, lats, lngs, color=None, c=None, **kwargs):
         color = color or c
         kwargs.setdefault("color", color)
@@ -204,6 +224,7 @@ class GoogleMapPlotter(object):
         self.write_paths(f)
         self.write_shapes(f)
         self.write_heatmap(f)
+        self.write_groundoverlay(f)
         f.write('\t}\n')
         f.write('</script>\n')
         f.write('</head>\n')
@@ -380,6 +401,17 @@ class GoogleMapPlotter(object):
             f.write('});' + '\n')
             f.write('heatmap.setMap(map);' + '\n')
             f.write(settings_string)
+
+    def write_groundoverlay(self, f):
+
+        for url, bounds_string in self.groundoverlays:
+            f.write(bounds_string)
+            f.write('var groundOverlay;' + '\n')
+            f.write('groundOverlay = new google.maps.GroundOverlay(' + '\n')
+            f.write('\n')
+            f.write("'" + url + "'," + '\n')
+            f.write('imageBounds);' + '\n')
+            f.write('groundOverlay.setMap(map);' + '\n')
 
 if __name__ == "__main__":
 

--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -169,9 +169,26 @@ class GoogleMapPlotter(object):
         return settings_string
 
     def groundoverlay(self, url, bounds_dict):
-        """
 
-        """
+        '''
+
+        :param url: Url of image to overlay
+        :param bounds_dict: dict of the form  {'north': , 'south': , 'west': , 'east': }
+        setting the image container
+        :return:
+
+        Example use:
+        import gmplot
+        gmap = gmplot.GoogleMapPlotter(37.766956, -122.438481, 13)
+        bounds_dict = {'north':37.832285, 'south': 37.637336, 'west': -122.520364, 'east': -122.346922}
+        gmap.groundoverlay('http://explore.museumca.org/creeks/images/TopoSFCreeks.jpg', bounds_dict)
+        gmap.draw("my_map.html")
+
+        Google Maps API documentation
+        https://developers.google.com/maps/documentation/javascript/groundoverlays#introduction
+
+        '''
+
 
         bounds_string = self._process_groundoverlay_image_bounds(bounds_dict)
 

--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -24,7 +24,7 @@ class GoogleMapPlotter(object):
         self.shapes = []
         self.points = []
         self.heatmap_points = []
-        self.groundoverlays = []
+        self.ground_overlays = []
         self.radpoints = []
         self.gridsetting = None
         self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png')
@@ -166,34 +166,26 @@ class GoogleMapPlotter(object):
 
         return settings_string
 
-    def groundoverlay(self, url, bounds_dict):
-
+    def ground_overlay(self, url, bounds_dict):
         '''
-
         :param url: Url of image to overlay
         :param bounds_dict: dict of the form  {'north': , 'south': , 'west': , 'east': }
         setting the image container
-        :return:
-
+        :return: None
         Example use:
         import gmplot
         gmap = gmplot.GoogleMapPlotter(37.766956, -122.438481, 13)
         bounds_dict = {'north':37.832285, 'south': 37.637336, 'west': -122.520364, 'east': -122.346922}
-        gmap.groundoverlay('http://explore.museumca.org/creeks/images/TopoSFCreeks.jpg', bounds_dict)
+        gmap.ground_overlay('http://explore.museumca.org/creeks/images/TopoSFCreeks.jpg', bounds_dict)
         gmap.draw("my_map.html")
-
         Google Maps API documentation
         https://developers.google.com/maps/documentation/javascript/groundoverlays#introduction
-
         '''
 
+        bounds_string = self._process_ground_overlay_image_bounds(bounds_dict)
+        self.ground_overlays.append((url, bounds_string))
 
-        bounds_string = self._process_groundoverlay_image_bounds(bounds_dict)
-
-        self.groundoverlays.append((url, bounds_string))
-
-    def _process_groundoverlay_image_bounds(self, bounds_dict):
-
+    def _process_ground_overlay_image_bounds(self, bounds_dict):
         bounds_string = 'var imageBounds = {'
         bounds_string += "north:  %.4f,\n" % bounds_dict['north']
         bounds_string += "south:  %.4f,\n" % bounds_dict['south']
@@ -233,7 +225,7 @@ class GoogleMapPlotter(object):
         self.write_paths(f)
         self.write_shapes(f)
         self.write_heatmap(f)
-        self.write_groundoverlay(f)
+        self.write_ground_overlay(f)
         f.write('\t}\n')
         f.write('</script>\n')
         f.write('</head>\n')
@@ -405,9 +397,9 @@ class GoogleMapPlotter(object):
             f.write('heatmap.setMap(map);' + '\n')
             f.write(settings_string)
 
-    def write_groundoverlay(self, f):
+    def write_ground_overlay(self, f):
 
-        for url, bounds_string in self.groundoverlays:
+        for url, bounds_string in self.ground_overlays:
             f.write(bounds_string)
             f.write('var groundOverlay;' + '\n')
             f.write('groundOverlay = new google.maps.GroundOverlay(' + '\n')


### PR DESCRIPTION
Adds GroundOverlay functionality to gmplot

Add groundoverlay(url, bounds_dict) method to overlay image at url over lat/lon container defined in bounds_dict. 

Useful to overlay images of any sort, either figurative (an old map; the picture of a site of interest) or data-driven (such as those generated by plt.imshow )

An example use case:

```
import gmplot
gmap = gmplot.GoogleMapPlotter(37.766956, -122.438481, 13)
bounds_dict = {'north':37.832285, 'south': 37.637336, 'west': -122.520364, 'east': -122.346922}
gmap.groundoverlay('http://explore.museumca.org/creeks/images/TopoSFCreeks.jpg', bounds_dict)
gmap.draw("my_map.html")
```
